### PR TITLE
Add functionality to control a stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ All requests to the API must be authorized using the `Authorization` HTTP header
 - **`PATCH/PUT /stacks/<stack_uuid>`**: Update a stack.
 - **`DELETE /stacks/<stack_uuid>`**: Delete a stack.
 - **`POST /stacks/<stack_uuid>/webhook`**: Trigger a stack update.
+- **`POST /stacks/<stack_uuid>/control`**: Control the stack (start, stop, restart).
 - **`GET /up`**: Check the health of the Supervisor service. (No authorization required)
 
 ### Creating a Stack
@@ -175,6 +176,19 @@ curl --request DELETE \
   --header "Authorization: Bearer 8db7fde4-6a11-462e-ba27-6897b7c9281b" \
   --verbose \
   https://supervisor.example.com/stacks/<stack_uuid>
+```
+
+### Control Stack
+
+To control a stack (start, stop, restart):
+
+```
+curl --request POST \
+  --silent \
+  --header "Authorization: Bearer 8db7fde4-6a11-462e-ba27-6897b7c9281b" \
+  --verbose \
+  --json '{ "method": "start" }' \
+  https://supervisor.example.com/stacks/<stack_uuid>/control
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ curl --request POST \
   --silent \
   --header "Authorization: Bearer 8db7fde4-6a11-462e-ba27-6897b7c9281b" \
   --verbose \
-  --json '{ "method": "start" }' \
+  --json '{ "command": "start" }' \
   https://supervisor.example.com/stacks/<stack_uuid>/control
 ```
 

--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -1,5 +1,5 @@
 class StacksController < ApplicationController
-  before_action :set_stack, only: %i[show update destroy stats webhook]
+  before_action :set_stack, only: %i[show update destroy stats webhook control]
   before_action :authorize, except: :webhook
   before_action :validate_signature, only: :webhook
 
@@ -46,6 +46,16 @@ class StacksController < ApplicationController
   # GET /stacks/${uuid}/stats
   def stats
     render json: @stack.stats.merge(uuid: @stack.uuid)
+  end
+
+  # POST /stacks/${uuid}/control
+  def control
+    method = params[:method]
+
+    allowed_methods = %w[start stop restart]
+    return render json: { error: 'Invalid control method' }, status: :bad_request if allowed_methods.exclude?(method)
+
+    @stack.send(method.to_sym)
   end
 
   # POST /stacks/${uuid}/webhook

--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -50,12 +50,12 @@ class StacksController < ApplicationController
 
   # POST /stacks/${uuid}/control
   def control
-    method = params[:method]
+    command = params[:command]
 
-    allowed_methods = %w[start stop restart]
-    return render json: { error: 'Invalid control method' }, status: :bad_request if allowed_methods.exclude?(method)
+    allowed_commands = %w[start stop restart]
+    return render json: { error: 'Invalid control command' }, status: :bad_request if allowed_commands.exclude?(command)
 
-    @stack.send(method.to_sym)
+    @stack.send(command.to_sym)
   end
 
   # POST /stacks/${uuid}/webhook

--- a/app/jobs/concerns/stack_job/runs_control_script.rb
+++ b/app/jobs/concerns/stack_job/runs_control_script.rb
@@ -1,0 +1,40 @@
+class StackJob
+  module RunsControlScript
+    extend ActiveSupport::Concern
+
+    included do
+      private
+
+      def render_script(stack, assets)
+        <<~SCRIPT
+          #!/bin/sh
+          set -e
+
+          control_stack() {
+            cd #{assets.git_dir}
+
+            sudo docker --log-level error \
+              compose --progress plain \
+              --file #{stack.compose_file} #{assets.include_files} \
+              --env-file #{assets.env_file} \
+              #{self.class.action} || true
+          }
+
+          control_stack
+        SCRIPT
+      end
+    end
+
+    class_methods do
+      def action(name = nil)
+        if name.present?
+          @action = name.to_s
+        elsif defined?(@action)
+          @action
+        else
+          @action = 'start'
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/stack_job.rb
+++ b/app/jobs/stack_job.rb
@@ -28,12 +28,19 @@ class StackJob < ApplicationJob
   def execute
     script = render_script(@stack, @assets)
     run_script(script)
+
+    stats_jobs = [
+      StackDeployJob,
+      StackPollingJob,
+      StackWebhookJob
+    ]
+    return if stats_jobs.exclude?(self.class)
     return if noop?
 
     @stack.update_stats(success: success?)
   end
 
-  def render_script(_stack, _assets)
+  def render_script(*)
     raise "#{self.class} must implement the method #{__method__}"
   end
 

--- a/app/jobs/stack_restart_job.rb
+++ b/app/jobs/stack_restart_job.rb
@@ -1,0 +1,7 @@
+class StackRestartJob < StackJob
+  include StackJob::RunsControlScript
+
+  queue_as :deploy
+
+  action :restart
+end

--- a/app/jobs/stack_start_job.rb
+++ b/app/jobs/stack_start_job.rb
@@ -1,0 +1,7 @@
+class StackStartJob < StackJob
+  include StackJob::RunsControlScript
+
+  queue_as :deploy
+
+  action :start
+end

--- a/app/jobs/stack_stop_job.rb
+++ b/app/jobs/stack_stop_job.rb
@@ -1,0 +1,7 @@
+class StackStopJob < StackJob
+  include StackJob::RunsControlScript
+
+  queue_as :deploy
+
+  action :stop
+end

--- a/app/models/concerns/stack/performs_job.rb
+++ b/app/models/concerns/stack/performs_job.rb
@@ -6,6 +6,18 @@ class Stack
       after_save_commit    :perform_deploy_job
       after_destroy_commit :perform_destroy_job
 
+      def start
+        StackStartJob.perform_later(self)
+      end
+
+      def stop
+        StackStopJob.perform_later(self)
+      end
+
+      def restart
+        StackRestartJob.perform_later(self)
+      end
+
       private
 
       def perform_deploy_job

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "414e26f4571ad814d0427faf294d2dd126170e1e55325a6be1e9cb2e08253dec",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/stacks_controller.rb",
+      "line": 58,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "Stack.find_by!(:uuid => params[:uuid]).send(params[:method].to_sym)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "StacksController",
+        "method": "control"
+      },
+      "user_input": "params[:method].to_sym",
+      "confidence": "High",
+      "cwe_id": [
+        77
+      ],
+      "note": "User input is verified by exclude clause"
+    }
+  ],
+  "updated": "2024-11-01 18:26:14 +0100",
+  "brakeman_version": "6.2.2"
+}

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,27 +3,27 @@
     {
       "warning_type": "Dangerous Send",
       "warning_code": 23,
-      "fingerprint": "414e26f4571ad814d0427faf294d2dd126170e1e55325a6be1e9cb2e08253dec",
+      "fingerprint": "63882a8ffe1934e347e4599d7c873cdafd65959dd4ea1ecd627f5f25f8f1a10b",
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "app/controllers/stacks_controller.rb",
       "line": 58,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "Stack.find_by!(:uuid => params[:uuid]).send(params[:method].to_sym)",
+      "code": "Stack.find_by!(:uuid => params[:uuid]).send(params[:command].to_sym)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "StacksController",
         "method": "control"
       },
-      "user_input": "params[:method].to_sym",
+      "user_input": "params[:command].to_sym",
       "confidence": "High",
       "cwe_id": [
         77
       ],
-      "note": "User input is verified by exclude clause"
+      "note": "User input is verified in previous code"
     }
   ],
-  "updated": "2024-11-01 18:26:14 +0100",
+  "updated": "2024-11-02 09:57:25 +0100",
   "brakeman_version": "6.2.2"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   resources :stacks, param: :uuid
   post 'stacks/:uuid/webhook', to: 'stacks#webhook', as: :stack_webhook
   get 'stacks/:uuid/stats', to: 'stacks#stats', as: :stack_stats
+  post 'stacks/:uuid/control', to: 'stacks#control', as: :stack_control
 end

--- a/spec/models/stack_spec.rb
+++ b/spec/models/stack_spec.rb
@@ -85,5 +85,32 @@ RSpec.describe Stack, type: :model do
         expect(stack).not_to be_webhook
       end
     end
+
+    describe '#start' do
+      it 'enqueues a StackStartJob' do
+        allow(StackStartJob).to receive(:perform_later).and_return(true)
+
+        stack.start
+        expect(StackStartJob).to have_received(:perform_later).with(stack)
+      end
+    end
+
+    describe '#stop' do
+      it 'enqueues a StackStopJob' do
+        allow(StackStopJob).to receive(:perform_later).and_return(true)
+
+        stack.stop
+        expect(StackStopJob).to have_received(:perform_later).with(stack)
+      end
+    end
+
+    describe '#restart' do
+      it 'enqueues a StackRestartJob' do
+        allow(StackRestartJob).to receive(:perform_later).and_return(true)
+
+        stack.restart
+        expect(StackRestartJob).to have_received(:perform_later).with(stack)
+      end
+    end
   end
 end

--- a/spec/requests/stacks_spec.rb
+++ b/spec/requests/stacks_spec.rb
@@ -226,20 +226,20 @@ RSpec.describe '/stacks', type: :request do
   end
 
   describe 'POST /control' do
-    context 'with invalid method' do
+    context 'with invalid command' do
       it 'renders a response with error' do
         stack = Stack.create! valid_attributes
-        post stack_control_url(stack.uuid), params: { method: 'invalid' }, headers: valid_headers, as: :json
+        post stack_control_url(stack.uuid), params: { command: 'invalid' }, headers: valid_headers, as: :json
         expect(response).not_to be_successful
         expect(response).to have_http_status(:bad_request)
-        expect(response.body).to include('Invalid control method')
+        expect(response.body).to include('Invalid control command')
       end
     end
 
-    context 'with valid method' do
+    context 'with valid command' do
       it 'renders a response with success' do
         stack = Stack.create! valid_attributes
-        post stack_control_url(stack.uuid), params: { method: 'start' }, headers: valid_headers, as: :json
+        post stack_control_url(stack.uuid), params: { command: 'start' }, headers: valid_headers, as: :json
         expect(response).to be_successful
         expect(response).to have_http_status(:no_content)
       end

--- a/spec/routing/stacks_routing_spec.rb
+++ b/spec/routing/stacks_routing_spec.rb
@@ -35,5 +35,9 @@ RSpec.describe StacksController, type: :routing do
     it 'routes to #stats' do
       expect(get: "/stacks/#{uuid}/stats").to route_to('stacks#stats', uuid:)
     end
+
+    it 'routes to #control' do
+      expect(post: "/stacks/#{uuid}/control").to route_to('stacks#control', uuid:)
+    end
   end
 end


### PR DESCRIPTION
This PR adds the functionality to control a stack.

* `start`
* `stop`
* `restart`

The related endpoint has the route `POST /stacks/:uuid/control` and expects the JSON body `{ "method": "start" }`.
Controlling a stack has no impact on the strategy. A running polling job is untouched.